### PR TITLE
Disable check mode for variable capture commands

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -6,6 +6,7 @@
   command: mysql -NBe "SELECT Host FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')"
   register: mysql_remote_root_hosts
   changed_when: false
+  check_mode: no
 
 - name: ensure remote root users are removed
   mysql_user:
@@ -18,6 +19,7 @@
   command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = 'root' ORDER BY (Host='localhost') ASC"
   register: mysql_root_hosts
   changed_when: false
+  check_mode: no
 
 - name: ensure root user has password set
   mysql_user:
@@ -32,6 +34,7 @@
 - command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = ''"
   register: mysql_anonymous_hosts
   changed_when: false
+  check_mode: no
 
 - name: ensure anonymous users are removed
   mysql_user:

--- a/tasks/security/root_auth_plugin.yml
+++ b/tasks/security/root_auth_plugin.yml
@@ -7,12 +7,14 @@
   command: mysql -NBe "DESCRIBE mysql.user plugin"
   register: mysql_check_new_auth
   changed_when: false
+  check_mode: no
   when: "mysql_root_password|default('') != ''"
 
 - name: check auth plugin of root user
   command: mysql -NBe "SELECT plugin FROM mysql.user WHERE User = 'root' AND plugin != 'mysql_native_password'"
   register: mysql_check_root_auth_plugin
   changed_when: false
+  check_mode: no
   when: "mysql_root_password|default('') != '' and mysql_check_new_auth.stdout != ''"
 
 - name: ensure root user has password set using mysql_native_password

--- a/tasks/security/temp_root_password.yml
+++ b/tasks/security/temp_root_password.yml
@@ -7,6 +7,7 @@
   shell: 'grep -s -o "temporary password.*" /var/log/mysqld.log | sed "s/.*: \(.\+\)/\1/"'
   register: mysql_temporary_root_password
   changed_when: false
+  check_mode: no
 
 - name: reset expired temporary root password
   command: "mysql -uroot -p{{ mysql_temporary_root_password.stdout }} --connect-expired-password -NBe \"ALTER USER root@localhost IDENTIFIED BY '{{ mysql_root_password }}'\""

--- a/tasks/timezones.yml
+++ b/tasks/timezones.yml
@@ -2,6 +2,7 @@
 - command: mysql -NBe "SELECT COUNT(*) FROM mysql.time_zone"
   register: mysql_timezones_count
   changed_when: false
+  check_mode: no
 
 - name: ensure timezone data is imported
   shell: "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql mysql"


### PR DESCRIPTION
This role doesn't currently support running in `--check` mode because the commands that capture output for later processing don't actually perform the capture in check mode. This PR forces those commands to run in normal mode so that capture occurs. 