### PR TITLE
Use fact ansible_distribution_major_version for Fedora and CentOS

### DIFF
--- a/tasks/install/upstream_mariadb_yum.yml
+++ b/tasks/install/upstream_mariadb_yum.yml
@@ -1,7 +1,7 @@
 ---
 - name: define distribution value for mariadb upstream repository
   set_fact:
-    mysql_upstream_dist: "{% if ansible_distribution == 'Fedora' %}fedora24{% else %}rhel{{ ansible_distribution_version }}{% endif %}"
+    mysql_upstream_dist: "{% if ansible_distribution == 'Fedora' %}fedora{{ ansible_distribution_major_version }}{% elif ansible_distribution == 'CentOS' %}centos{{ ansible_distribution_major_version }}{% else %}rhel{{ ansible_distribution_version }}{% endif %}"
 
 - name: ensure yum repository for mariadb upstream is configured
   yum_repository:


### PR DESCRIPTION
On my CentOS 7 machine installing from upstream MariaDB 10.2 didn't work without this patch.