### PR TITLE
Validation; Bugfixes; Sensible Defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+meta/.galaxy_install_info

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ Additional configuration can be defined in the variable `mysql_custom_config`, f
 
 ### Backup
 
-By default a backup script is installed which runs daily.
+While backups are disabled by default, an automatic daily backup script can be enabled by setting `mysql_backup` to `yes`.
+
 It simply dumps all databases to the directory defined in `mysql_backup_destination` as an SQL file with a timestamp.
 Additionally it links the latest backup file per database to `[database]_latest.sql`.
 
-The backup can be disabled with setting the variable `mysql_backup` to `false`.
-
 A database user for the backup will be created automatically with the password set in the variable `mysql_backup_password`.
+Be sure to set this variable to a sensible password, as it is empty be default and an error will be thrown if backups are enabled and this password is not set.
 
 ### Firewall
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Available variables are listed below, along with default values:
 
     mysql_custom_config: ~
 
-    mysql_backup: yes
+    mysql_backup: no
     mysql_backup_destination: /var/lib/backup/database
     mysql_backup_password: "My $3cr3t password"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ mysql_vendor: mysql
 mysql_origin: distribution
 mysql_upstream_version: ~ # MariaDB: 10.2, MySQL: 5.7
 
-mysql_root_password: "My $3cr3t password"
+mysql_root_password: ~
 
 mysql_import_timezones: yes
 
@@ -30,7 +30,7 @@ mysql_custom_config: ~
 
 mysql_backup: no
 mysql_backup_destination: /var/lib/backup/database
-mysql_backup_password: "My $3cr3t password"
+mysql_backup_password: ~
 
 mysql_firewall_zones: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ mysql_ssl_key: ~
 
 mysql_custom_config: ~
 
-mysql_backup: yes
+mysql_backup: no
 mysql_backup_destination: /var/lib/backup/database
 mysql_backup_password: "My $3cr3t password"
 

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -12,5 +12,5 @@
     name: "{{ item.item.name }}"
     state: import
     target: "{{ item.item.import_file }}"
-  when: item.changed and item.item.import_file
+  when: item.changed and item.item.import_file is defined and item.item.import_file
   with_items: "{{ mysql_databases_created.results }}"

--- a/tasks/install/upstream_mysql_yum.yml
+++ b/tasks/install/upstream_mysql_yum.yml
@@ -1,7 +1,7 @@
 ---
 - name: define distribution value for mysql upstream repository
   set_fact:
-    mysql_upstream_dist: "{% if ansible_distribution == 'Fedora' %}fc{% else %}el{% endif %}{{ ansible_distribution_version }}"
+    mysql_upstream_dist: "{% if ansible_distribution == 'Fedora' %}fc{% else %}el{% endif %}{{ ansible_distribution_major_version }}"
 
 - name: ensure mysql upstream repository is installed
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,8 @@
    - "{{ mysql_vendor }}/{{ ansible_distribution }}.yml"
    - "{{ mysql_vendor }}/{{ ansible_os_family }}.yml"
 
+- include: validation.yml
+   
 - name: define upstream version
   set_fact:
     mysql_upstream_version: "{% if mysql_vendor == 'mysql' %}5.7{% else %}10.2{% endif %}"

--- a/tasks/validation.yml
+++ b/tasks/validation.yml
@@ -1,0 +1,17 @@
+---
+- name: verify variable 'mysql_root_password' has been changed from the default
+  fail:
+    msg: "'mysql_root_password' variable has not been changed from the default. Using the default 'mysql_root_password' is a security risk"
+  when: mysql_root_password == "My $3cr3t password"
+
+- debug: var=mysql_backup
+  
+- name: verify variable 'mysql_backup_password' has been changed from the default
+  fail:
+    msg: "'mysql_backup_password' variable has not been changed from the default. Using the default 'mysql_backup_password' is a security risk"
+  when: mysql_backup != false and mysql_backup_password == "My $3cr3t password"
+  
+- name: verify variables 'mysql_vendor' and 'mysql_origin' are consistent
+  fail:
+    msg: "variables 'mysql_vendor' and 'mysql_origin' are inconsistent. RedHat/CentOS/Fedora do not distribute MySQL community edition. Set mysql_origin=upstream"
+  when: mysql_vendor == 'mysql' and mysql_origin == 'distribution' and ansible_os_family == 'RedHat'

--- a/tasks/validation.yml
+++ b/tasks/validation.yml
@@ -4,13 +4,11 @@
     msg: "'mysql_root_password' variable has not been changed from the default. Using the default 'mysql_root_password' is a security risk"
   when: mysql_root_password == "My $3cr3t password"
 
-- debug: var=mysql_backup
-  
 - name: verify variable 'mysql_backup_password' has been changed from the default
   fail:
     msg: "'mysql_backup_password' variable has not been changed from the default. Using the default 'mysql_backup_password' is a security risk"
   when: mysql_backup != false and mysql_backup_password == "My $3cr3t password"
-  
+
 - name: verify variables 'mysql_vendor' and 'mysql_origin' are consistent
   fail:
     msg: "variables 'mysql_vendor' and 'mysql_origin' are inconsistent. RedHat/CentOS/Fedora do not distribute MySQL community edition. Set mysql_origin=upstream"

--- a/tasks/validation.yml
+++ b/tasks/validation.yml
@@ -2,14 +2,14 @@
 - name: verify variable 'mysql_root_password' has been changed from the default
   fail:
     msg: "'mysql_root_password' variable has not been changed from the default. Using the default 'mysql_root_password' is a security risk"
-  when: mysql_root_password == "My $3cr3t password"
+  when: mysql_root_password is none
 
 - name: verify variable 'mysql_backup_password' has been changed from the default
   fail:
     msg: "'mysql_backup_password' variable has not been changed from the default. Using the default 'mysql_backup_password' is a security risk"
-  when: mysql_backup != false and mysql_backup_password == "My $3cr3t password"
+  when: mysql_backup != false and mysql_backup_password is none
 
 - name: verify variables 'mysql_vendor' and 'mysql_origin' are consistent
   fail:
-    msg: "variables 'mysql_vendor' and 'mysql_origin' are inconsistent. RedHat/CentOS/Fedora do not distribute MySQL community edition. Set mysql_origin=upstream"
-  when: mysql_vendor == 'mysql' and mysql_origin == 'distribution' and ansible_os_family == 'RedHat'
+    msg: "variables 'mysql_vendor' and 'mysql_origin' are inconsistent. CentOS do not distribute MySQL community edition. Set mysql_origin=upstream"
+  when: mysql_vendor == 'mysql' and mysql_origin == 'distribution' and ansible_distribution == 'CentOS'


### PR DESCRIPTION
After using this role on our infrastructure I encountered some bugs and thought of some improvements:

1. When I used the role for the first time on an LXC container running CentOS 7, it did not work since I chose I was trying to install MySQL community edition and I had set "mysql_origin=distribution". CentOS do not distribute MySQL community edition, so the role failed. Commit 0910c25 fixes this by alerting the user when they make this invalid selection.
2. When installing MySQL community edition from 'mysql_origin=upstream' on CentOS 7, the upstream YUM repo did not install because the version number of the distribution was too specific. The Ansible variable 'ansible_distribution_version' was used which lead to "7.4.1708" being inserted into the repo URL. Commit 1bf2354 fixes this by using the 'ansible_distribution_major_version' variable.
3. The role sets up backups by default, while a useful feature, I found the 'on by default' behaviour a nuisance as I have my own backup setup and did not require the role to create one. It is also difficult to undo and uses the default password. I thought a more sensible default was to have it disabled. Commit eae258b fixes this
4. Finally there is a security risk by including default MySQL passwords and accepting them when applying the role. I thought a sanity check to alert the user when they have not set a root or backup password would be a good security improvement. Commit 0910c25 fixes this.
5. I was not importing any databases, I was creating new, empty schemas. When I did not specify 'mysql_databases.item.import_file'. Commit 708851d fixes this by checking is 'mysql_databases.item.import_file' defined before it validates it. This way Ansible gracefully ignores the absence of the variable which it does not require in any case, since it is happy to proceed without importing anything.