### PR TITLE
Updated default mysql_upstream_version from 5.7 to 8.0 after eol of 5.7

### DIFF
--- a/tasks/install/upstream_mysql_yum.yml
+++ b/tasks/install/upstream_mysql_yum.yml
@@ -5,4 +5,4 @@
 
 - name: ensure mysql upstream repository is installed
   package:
-    name: "http://dev.mysql.com/get/mysql{{ mysql_upstream_version | replace('.', '') }}-community-release-{{ mysql_upstream_dist }}-9.noarch.rpm"
+    name: "http://dev.mysql.com/get/mysql{{ mysql_upstream_version | replace('.', '') }}-community-release-{{ mysql_upstream_dist }}-1.noarch.rpm"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,10 @@
    - "{{ mysql_vendor }}/{{ ansible_os_family }}.yml"
 
 - include: validation.yml
-   
+
 - name: define upstream version
   set_fact:
-    mysql_upstream_version: "{% if mysql_vendor == 'mysql' %}5.7{% else %}10.2{% endif %}"
+    mysql_upstream_version: "{% if mysql_vendor == 'mysql' %}8.0{% else %}10.2{% endif %}"
   when: not mysql_upstream_version
 
 - include: install/upstream_mysql_yum.yml


### PR DESCRIPTION
MySQL 8.0 has been released (https://dev.mysql.com/downloads/mysql/) as a result the URL 'http://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm' for the yum repository package is no longer valid giving the following error if 'mysql_upstream_version' is left at the default '5.7'

`TASK [ansible-galaxy/mjanser.mysql : ensure mysql upstream repository is installed] fatal: [host-example.com]: FAILED! => {"changed": false, "msg": "Failure downloading http://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm, HTTP Error 404: Not Found"}`

I have fixed this by setting the default 'mysql_upstream_version' to '8.0'. Obvioulsy, an implication of this fix is that the default MySQL version is now 8.0. If this is acceptable, great, please merge.

However if this is not acceptable, it is possible to continue using MySQL 5.7 as it is available in the community yum repository (https://dev.mysql.com/downloads/repo/yum/), however the yum repo URL composition will have to be split from the 'mysql_upstream_version' variable. While the repo does contain version '5.7', the repo package can only be found at the URL: 'http://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm'